### PR TITLE
adding the jekyll-redirect-from plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 3.8.3"
 
+gem "jekyll-redirect-from"
+
 group :jekyll_plugins do
   gem 'jekyll_pages_api_search'
   gem 'jekyll-sitemap'

--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,11 @@ jekyll_pages_api_search:
     body:
   results_page_title: Search results
 
+# The Jekyll Redirect From Plugin
+# https://github.com/jekyll/jekyll-redirect-from
+plugins:
+  - jekyll-redirect-from
+
 # Build settings
 scripts:
   - assets/uswds/js/uswds.min.js

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -20,4 +20,9 @@ cards:
 - heading: Get help with the PRA
   body: Find agency resources to help you prepare your request.
   href: /contact/
+
+redirect_from:
+  - /tools/
+  - /playbook/
+
 ---


### PR DESCRIPTION
There is a need to create redirects in the site.
This plugin makes that possible.

As a test, this page **https://pra.digital.gov/tools/** should redirect to the homepage.

