### PR TITLE
Adding Sitemap link to the head

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,7 @@ jekyll_pages_api_search:
 # https://github.com/jekyll/jekyll-redirect-from
 plugins:
   - jekyll-redirect-from
+  - jekyll-sitemap
 
 # Build settings
 scripts:

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -12,4 +12,7 @@
 <meta name="description" content="{{ description }}">
 {% endif %}
 
+<!-- Sitemap-->
+<link rel="sitemap" type="application/xml" title="{{ site.title }} Sitemap" href="/sitemap.xml" />
+
 {% include favicon.html %}


### PR DESCRIPTION
This change adds a sitemap link to the head of the page, which will allow search engines to index the page. The sitemap has already been submitted to the search engines, but this could also help.