### PR TITLE
Add subagency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,13 @@ github:
   repository: digitalgov-pra
   default_branch: master
 
+analytics:
+  google:
+    code: UA-48605964-53
+  dap:
+    agency: GSA
+    subagency: TTS
+
 url: "https://pra.digital.gov" # the base hostname to generate the sitemap.xml via the jekyll-sitemap plugin
 
 page_gen:

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,8 +1,8 @@
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-48605964-53"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.code }}&agency={{ site.analytics.dap.agency }}&subagency={{ site.analytics.dap.subagency }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
-  gtag('config', 'UA-48605964-53');
+  gtag('config', '{{ site.analytics.google.code }}');
 </script>


### PR DESCRIPTION
Replaces PR #292. Federalist build doesn't run on forked/non-contributor branches.