### PR TITLE
Updated search input label for accessibility

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,7 +36,7 @@
         </ul>
         <form class="usa-search usa-search--small site-search" role="search" action="https://search.usa.gov/search" accept-charset="UTF-8" method="get">
           <input type="hidden" name="affiliate" id="affiliate" value="digitalgov-pra" autocomplete="off" />
-          <label for="query" class="usa-sr-only">Label Accessible</label>
+          <label for="query" class="usa-sr-only">Search</label>
           <input type="text" name="query" id="query" autocomplete="off" class="usagov-search-autocomplete" />
           <button class="usa-button" type="submit">
             <img

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,7 +36,7 @@
         </ul>
         <form class="usa-search usa-search--small site-search" role="search" action="https://search.usa.gov/search" accept-charset="UTF-8" method="get">
           <input type="hidden" name="affiliate" id="affiliate" value="digitalgov-pra" autocomplete="off" />
-          <label for="query" class="usa-sr-only"></label>
+          <label for="query" class="usa-sr-only">Label Accessible</label>
           <input type="text" name="query" id="query" autocomplete="off" class="usagov-search-autocomplete" />
           <button class="usa-button" type="submit">
             <img


### PR DESCRIPTION
## Summary

`label` for search `input` was missing a text description and causing the `input` to have an un-accessible name.
Could add an `aria-label="Search"` to the `input` instead?

**Before**
<img width="1087" alt="Screen Shot 2022-10-25 at 1 43 34 PM" src="https://user-images.githubusercontent.com/104778659/197848347-5e60da3c-27d6-40ff-80f3-9b3996fefbb3.png">

**After**
<img width="1192" alt="Screen Shot 2022-10-25 at 1 44 25 PM" src="https://user-images.githubusercontent.com/104778659/197848360-e20b2312-288c-4efc-bc38-8fb1e9a06160.png">
