### PR TITLE
Remove duplicate banner roles

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,7 +36,7 @@
         </ul>
         <form class="usa-search usa-search--small site-search" role="search" action="https://search.usa.gov/search" accept-charset="UTF-8" method="get">
           <input type="hidden" name="affiliate" id="affiliate" value="digitalgov-pra" autocomplete="off" />
-          <label for="query" class="usa-sr-only">Label Accessible</label>
+          <label for="query" class="usa-sr-only">Search</label>
           <input type="text" name="query" id="query" autocomplete="off" class="usagov-search-autocomplete" />
           <button class="usa-button" type="submit">
             <img

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <div class="usa-overlay"></div>
-<section class="usa-header usa-header--extended">
+<header class="usa-header usa-header--extended">
   <div class="usa-navbar">
     <div class="usa-logo" id="extended-logo">
       <em class="usa-logo__text"><a href="{{ '/' | relative_url }}" title="Home" aria-label="Home"><img src="{{ '/assets/img/guide-to-pra--desktop--light.svg' | relative_url }}" alt="{{site.title}}" class="display-block" /></a></em>
@@ -49,4 +49,4 @@
       </div>
     </div>
   </nav>
-</section>
+</header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <div class="usa-overlay"></div>
-<header class="usa-header usa-header--extended" role="banner">
+<section class="usa-header usa-header--extended">
   <div class="usa-navbar">
     <div class="usa-logo" id="extended-logo">
       <em class="usa-logo__text"><a href="{{ '/' | relative_url }}" title="Home" aria-label="Home"><img src="{{ '/assets/img/guide-to-pra--desktop--light.svg' | relative_url }}" alt="{{site.title}}" class="display-block" /></a></em>
@@ -49,4 +49,4 @@
       </div>
     </div>
   </nav>
-</header>
+</section>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -36,7 +36,7 @@
         </ul>
         <form class="usa-search usa-search--small site-search" role="search" action="https://search.usa.gov/search" accept-charset="UTF-8" method="get">
           <input type="hidden" name="affiliate" id="affiliate" value="digitalgov-pra" autocomplete="off" />
-          <label for="query" class="usa-sr-only"></label>
+          <label for="query" class="usa-sr-only">Label Accessible</label>
           <input type="text" name="query" id="query" autocomplete="off" class="usagov-search-autocomplete" />
           <button class="usa-button" type="submit">
             <img


### PR DESCRIPTION
## Summary

Removed dupe banner roles by changing `header` to `section`.

**Before**
`<header class="usa-header usa-header--extended" role="banner">`

**After**
`<section class="usa-header usa-header--extended">`

It was conflicting with `usa-banner` component.

**Screenshot**
<img width="1677" alt="Screen Shot 2022-10-25 at 4 10 35 PM" src="https://user-images.githubusercontent.com/104778659/197873532-e210b1c4-0395-4325-bd06-285c6f324a9a.png">



