### PR TITLE
Added main role to home page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,7 +3,7 @@ layout: default
 class: home
 ---
 
-<main>
+<main id="main-content">
   <div class="bg-primary text-white margin-bottom-3 tablet:margin-bottom-6" id="main-content">
     <div class="grid-container padding-y-3 tablet:padding-y-6">
       <div class="measure-1 font-heading-md tablet:font-heading-xl line-height-serif-4 margin-bottom-4">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -3,25 +3,27 @@ layout: default
 class: home
 ---
 
-<div class="bg-primary text-white margin-bottom-3 tablet:margin-bottom-6" id="main-content">
-  <div class="grid-container padding-y-3 tablet:padding-y-6">
-    <div class="measure-1 font-heading-md tablet:font-heading-xl line-height-serif-4 margin-bottom-4">
-      {{page.tagline}}
+<main>
+  <div class="bg-primary text-white margin-bottom-3 tablet:margin-bottom-6" id="main-content">
+    <div class="grid-container padding-y-3 tablet:padding-y-6">
+      <div class="measure-1 font-heading-md tablet:font-heading-xl line-height-serif-4 margin-bottom-4">
+        {{page.tagline}}
+      </div>
+      <a href="{{page.button.href | relative_url}}" class="usa-button usa-button--secondary width-auto">{{page.button.text}}</a>
     </div>
-    <a href="{{page.button.href | relative_url}}" class="usa-button usa-button--secondary width-auto">{{page.button.text}}</a>
   </div>
-</div>
-<div class="grid-container  margin-bottom-3 tablet:margin-bottom-6 usa-layout__docs-main">
-  <h2 class="hr font-family-serif margin-bottom-3 tablet:margin-bottom-6"><span>Get started with the PRA</span></h2>
-  <div class="grid-row grid-gap">
-  {% for card in page.cards %}
-    <div class="tablet:grid-col-4 display-flex margin-bottom-205 tablet:margin-bottom-0">
-      <a href="{{ card.href | relative_url}}" class="border border-base radius-sm padding-x-5 padding-y-3 tablet:padding-5 hover:bg-base-lightest hover:shadow-2 text-no-underline">
-        <h3 class="margin-top-0 text-primary-vivid icon-arrow font-heading-sm">{{ card.heading }}</h3>
-        <p class="text-ink margin-bottom-0 line-height-sans-4">{{ card.body }}</p>
-      </a>
+  <div class="grid-container  margin-bottom-3 tablet:margin-bottom-6 usa-layout__docs-main">
+    <h2 class="hr font-family-serif margin-bottom-3 tablet:margin-bottom-6"><span>Get started with the PRA</span></h2>
+    <div class="grid-row grid-gap">
+    {% for card in page.cards %}
+      <div class="tablet:grid-col-4 display-flex margin-bottom-205 tablet:margin-bottom-0">
+        <a href="{{ card.href | relative_url}}" class="border border-base radius-sm padding-x-5 padding-y-3 tablet:padding-5 hover:bg-base-lightest hover:shadow-2 text-no-underline">
+          <h3 class="margin-top-0 text-primary-vivid icon-arrow font-heading-sm">{{ card.heading }}</h3>
+          <p class="text-ink margin-bottom-0 line-height-sans-4">{{ card.body }}</p>
+        </a>
+      </div>
+    {% endfor %}
     </div>
-  {% endfor %}
-  </div>
-  {{ content }}
-</div>
+    {{ content }}
+  </div>  
+</main>


### PR DESCRIPTION
## Summary

Home page was missing `main` tag and role.

**Note**

`main` tag on homepage has no classes or id styles applied because of style differences between other pages, a padding gap from the top navbar that breaks the home page design.

`<main class="usa-layout-docs usa-section" id="main-content">` 

<img width="1679" alt="Screen Shot 2022-10-25 at 4 58 41 PM" src="https://user-images.githubusercontent.com/104778659/198053158-8d90cbf4-e0ec-4b22-88de-8166882f84e6.png">