### PR TITLE
Updated identifier markup for improved a11y with aria-label

### DIFF
--- a/_includes/identifier.html
+++ b/_includes/identifier.html
@@ -21,13 +21,13 @@
             role="img"
         /></a>
       </div>
-      <div class="usa-identifier__identity" aria-label="Agency description">
+      <section class="usa-identifier__identity" aria-label="Agency description">
         <p class="usa-identifier__identity-domain">pra.digital.gov</p>
         <p class="usa-identifier__identity-disclaimer">
           An official website of the <a href="https://www.gsa.gov/">U.S. General Services Administration</a> and
           the <a href="https://www.whitehouse.gov/omb/">Office of Management and Budget</a>
         </p>
-      </div>
+      </section>
     </div>
   </section>
   <nav


### PR DESCRIPTION
## Summary

AXE is flagging a section in the Identifier component which is out of sync with the current version of USWDS.

## How To

1. Use DevTools Chrome extension v4.4.2 [axe-core](https://github.com/dequelabs/axe-core) 
2. Run developer tools extension 
3. "Elements must only use allowed ARIA attributes" is listed in report

<img width="1678" alt="Screen Shot 2022-10-26 at 2 00 37 PM" src="https://user-images.githubusercontent.com/104778659/198102597-e2fbbbc7-6d89-4a05-8d6b-d57d0222d72c.png">

[USWDS 3 Identifier component](https://designsystem.digital.gov/components/identifier/) has this section of the identifier wrapped in a `section`.

```
<section class="usa-identifier__identity" aria-label="Agency description">
  <p class="usa-identifier__identity-domain">domain.gov</p>
  <p class="usa-identifier__identity-disclaimer">
    An official website of the <a href="">&lt;Parent agency&gt;</a>
  </p>
</section>
```


**Before**

```
<div class="usa-identifier__identity" aria-label="Agency description">
  <p class="usa-identifier__identity-domain">pra.digital.gov</p>
  <p class="usa-identifier__identity-disclaimer">
    An official website of the <a href="https://www.gsa.gov/">U.S. General Services Administration</a> and
    the <a href="https://www.whitehouse.gov/omb/">Office of Management and Budget</a>
  </p>
</div>
```

**After**

```
<section class="usa-identifier__identity" aria-label="Agency description">
  <p class="usa-identifier__identity-domain">pra.digital.gov</p>
  <p class="usa-identifier__identity-disclaimer">
    An official website of the <a href="https://www.gsa.gov/">U.S. General Services Administration</a> and
    the <a href="https://www.whitehouse.gov/omb/">Office of Management and Budget</a>
  </p>
</section>
```
