### PR TITLE
Ensure navigation landmarks are unique

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     </div>
     <button class="usa-menu-btn text-semibold">Menu</button>
   </div>
-  <nav aria-label="Primary" class="usa-nav">
+  <nav aria-label="Primary navigation" class="usa-nav">
     <div class="usa-nav__inner"><button class="usa-nav__close"><img src="{{ site.baseurl }}/assets/uswds/img/usa-icons/close.svg" alt="close" /></button>
 
       {% assign primary_links = site.data.navigation %} {% if primary_links %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
     </div>
     <button class="usa-menu-btn text-semibold">Menu</button>
   </div>
-  <nav role="navigation" class="usa-nav">
+  <nav aria-label="Primary" class="usa-nav">
     <div class="usa-nav__inner"><button class="usa-nav__close"><img src="{{ site.baseurl }}/assets/uswds/img/usa-icons/close.svg" alt="close" /></button>
 
       {% assign primary_links = site.data.navigation %} {% if primary_links %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,6 +1,6 @@
 <aside class="usa-layout__docs-sidenav desktop:grid-col-3 margin-top-4 desktop:margin-top-0 padding-top-4 order-last desktop:padding-top-0 desktop:order-first border-base border-top desktop:border-top-0">
   <div class="font-serif-xs margin-bottom-205">In this section:</div>
-  <nav aria-label="Secondary">
+  <nav aria-label="Secondary navigation">
     {% assign _url = page.url | split: '/' %}
     {% assign _parent_dir = _url[1] %}
     {% assign _parent_url = _parent_dir | relative_url | append: '/' %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,6 +1,6 @@
 <aside class="usa-layout__docs-sidenav desktop:grid-col-3 margin-top-4 desktop:margin-top-0 padding-top-4 order-last desktop:padding-top-0 desktop:order-first border-base border-top desktop:border-top-0">
   <div class="font-serif-xs margin-bottom-205">In this section:</div>
-  <nav>
+  <nav aria-label="something goes here!">
     {% assign _url = page.url | split: '/' %}
     {% assign _parent_dir = _url[1] %}
     {% assign _parent_url = _parent_dir | relative_url | append: '/' %}

--- a/_includes/sidenav.html
+++ b/_includes/sidenav.html
@@ -1,6 +1,6 @@
 <aside class="usa-layout__docs-sidenav desktop:grid-col-3 margin-top-4 desktop:margin-top-0 padding-top-4 order-last desktop:padding-top-0 desktop:order-first border-base border-top desktop:border-top-0">
   <div class="font-serif-xs margin-bottom-205">In this section:</div>
-  <nav aria-label="something goes here!">
+  <nav aria-label="Secondary">
     {% assign _url = page.url | split: '/' %}
     {% assign _parent_dir = _url[1] %}
     {% assign _parent_url = _parent_dir | relative_url | append: '/' %}


### PR DESCRIPTION
### Summary
Landmark navigation should read "Primary navigation" to distinguish from "Secondary navigation".

### Steps To Reproduce

1. Open http://localhost:4000/do-i-need-clearance/
2. Run Axe tools
3. See "Ensure landmarks are unique" issue

<img width="1677" alt="Screen Shot 2022-11-07 at 12 31 36 PM" src="https://user-images.githubusercontent.com/104778659/200408423-78f190ca-9391-49be-aa1a-9ab910c5ae3f.png">

### Solutions

New markup reads "Primary" or "Secondary" for the navigation menus.

`<nav aria-label="Primary" class="usa-nav">`



