### PR TITLE
Update default branch to main

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ email: pra@omb.eop.gov
 github:
   organization: GSA
   repository: digitalgov-pra
-  default_branch: master
+  default_branch: main
 
 analytics:
   google:


### PR DESCRIPTION
This PR updates the default branch in Jekyll config.

I've also updated:
- [x] Branch name in github
- [x] Cloud pages main branch 