### PR TITLE
Updated accessibility statement to be in sync with uswds 3.5.0

### DIFF
--- a/_includes/identifier.html
+++ b/_includes/identifier.html
@@ -42,8 +42,8 @@
           </a>
         </li>
         <li class="usa-identifier__required-links-item">
-          <a href="https://www.gsa.gov/website-information/accessibility-aids" class="usa-identifier__required-link usa-link">
-            Accessibility support
+          <a href="https://www.gsa.gov/website-information/accessibility-statement" class="usa-identifier__required-link usa-link">
+            Accessibility statement
           </a>
         </li>
         <li class="usa-identifier__required-links-item">


### PR DESCRIPTION
## Summary
Updated `usa-identifier` to match [uswds 3.5.0](https://designsystem.digital.gov/components/identifier/)

## Solution

- Rename `Accessibility support` to `Accessibility statement`
- Updated url from `https://www.gsa.gov/website-information/accessibility-aids` to `https://www.gsa.gov/website-information/accessibility-statement`

## Preview

- [Preview](https://federalist-ba11378c-de49-4b18-b3c7-6dde8c4aa829.sites.pages.cloud.gov/preview/gsa/digitalgov-pra/nl-update-identifier-a11y-statement/)