### PR TITLE
Fix code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/assets/uswds/js/uswds.js
+++ b/assets/uswds/js/uswds.js
@@ -628,7 +628,7 @@ var trim = String.prototype.trim ? function (str) {
   return str.replace(RE_TRIM, '');
 };
 var queryById = function (id) {
-  return this.querySelector('[id="' + id.replace(/"/g, '\\"') + '"]');
+  return this.querySelector('[id="' + id.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"]');
 };
 module.exports = function resolveIds(ids, doc) {
   if (typeof ids !== 'string') {


### PR DESCRIPTION
Fixes [https://github.com/GSA/digitalgov-pra/security/code-scanning/1](https://github.com/GSA/digitalgov-pra/security/code-scanning/1)

To fix the problem, we need to ensure that all special characters, including backslashes, are properly escaped in the `id` parameter before it is used in the query selector. The best way to achieve this is by using a regular expression with the global flag to replace all occurrences of the special characters.

We will modify the `queryById` function to escape backslashes and double quotes. This involves updating the `replace` method to handle backslashes correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
